### PR TITLE
eigen database tables public gemaakt, generate hour rows functie

### DIFF
--- a/UrenRegistratieQien/Data/ApplicationDbContext.cs
+++ b/UrenRegistratieQien/Data/ApplicationDbContext.cs
@@ -16,9 +16,9 @@ namespace UrenRegistratieQien.Data
 
         }
 
-        DbSet<Employee> Employees { get; set; }
-        DbSet<Client> Clients { get; set; }
-        DbSet<HourRow> HourRows { get; set; }
-        DbSet<DeclarationForm> DeclarationForms { get; set; }
+        public DbSet<Employee> Employees { get; set; }
+        public DbSet<Client> Clients { get; set; }
+        public DbSet<HourRow> HourRows { get; set; }
+        public DbSet<DeclarationForm> DeclarationForms { get; set; }
     }
 }

--- a/UrenRegistratieQien/Data/Migrations/20191119094957_nuMetPublic.Designer.cs
+++ b/UrenRegistratieQien/Data/Migrations/20191119094957_nuMetPublic.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using UrenRegistratieQien.Data;
 
 namespace UrenRegistratieQien.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20191119094957_nuMetPublic")]
+    partial class nuMetPublic
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/UrenRegistratieQien/Data/Migrations/20191119094957_nuMetPublic.cs
+++ b/UrenRegistratieQien/Data/Migrations/20191119094957_nuMetPublic.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace UrenRegistratieQien.Data.Migrations
+{
+    public partial class nuMetPublic : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EmployeeId",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "Role",
+                table: "AspNetUsers");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "EmployeeId",
+                table: "AspNetUsers",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Role",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+    }
+}

--- a/UrenRegistratieQien/Repositories/HourRowRepository.cs
+++ b/UrenRegistratieQien/Repositories/HourRowRepository.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using UrenRegistratieQien.Data;
+using UrenRegistratieQien.DatabaseClasses;
 
 namespace UrenRegistratieQien.Repositories
 {
@@ -17,7 +18,31 @@ namespace UrenRegistratieQien.Repositories
         }
         public void GetHourRows()
         {
+            
+        }
 
+        public void GenerateHourRows(int year, int month, int declarationFormId)
+        {
+            int days = DateTime.DaysInMonth(year, month);
+            for (var i=1; i<days; i++)
+            {
+                
+                HourRow hourRow = new HourRow
+                {
+                    Date = Convert.ToString(i) + "/" + Convert.ToString(month) + "/" + Convert.ToString(year),
+                    Worked = 0,
+                    Overtime = 0,
+                    Sickness = 0,
+                    Vacation = 0,
+                    Holiday = 0,
+                    Training = 0,
+                    Other = 0,
+                    OtherExplanation = "",
+                    DeclarationFormId = declarationFormId
+                };
+
+                context.HourRows.Add(hourRow);
+            }
         }
     }
 }


### PR DESCRIPTION
We konden niet bij onze tables door protection level issues, dus hebben we onze eigen database classes op public gezet. Nu kun je add-migration doen om dit toe te passen op je eigen database

ook toegevoegd:
generate hour rows functie